### PR TITLE
Update 0.index.md

### DIFF
--- a/docus/content/0.index.md
+++ b/docus/content/0.index.md
@@ -5,7 +5,7 @@ navigation: false
 
 This document is a best-effort, community maintained, support matrix of recent Mastodon releases and their underlying dependencies.
 It is designed to provide high-level guidance for determining upgrade paths, and what to deploy in an environment.
-Administrators should also consult the the release notes for your version of Mastodon, and any product dependencies, before upgrading.
+Administrators should also consult the release notes for your version of Mastodon, and any product dependencies, before upgrading.
 
 For questions, comments or concerns please reach out to [@vmstan@vmst.io](https://vmst.io/@vmstan).
 
@@ -16,7 +16,7 @@ For questions, comments or concerns please reach out to [@vmstan@vmst.io](https:
 ## Matrix
 
 ::alert{type="success"}
-The four most recent branches of Mastodon are listed across the top of each table. 4.4/Dev, 4.3/Release, 4.2/Previous, 4.1/EOL. The version of each required component is on the left side of the table.
+The most recent branches of Mastodon are listed across the top of each table. 4.5/Dev, 4.4/Release 4.3/Release, 4.2/Previous, 4.1/EOL. The version of each required component is on the left side of the table.
 ::
 
 ::alert{type="warning"}
@@ -150,17 +150,17 @@ Elasticsearch 8.x (which still has the Mastodon-required 7.x APIs) or OpenSearch
 | 6.x               |    :icon{name="twemoji:cross-mark"}     |      :icon{name="twemoji:cross-mark"}      |    :icon{name="twemoji:cross-mark"}     |    :icon{name="twemoji:cross-mark"}     |
 
 ::alert{type="success"}
-Mastodon is transitioning from ImageMagick to libvips starting with Mastodon 4.3, which provides better performance.
+Mastodon transitioned from ImageMagick to libvips starting with Mastodon 4.3, which provides better performance.
 Unless you are unable to run libvips 8.13+ on your system, you should switch from ImageMagick as soon as possible.
 Support for ImageMagick will be removed in an upcoming release.
 ::
 
 ::alert{type="info"}
-The official Mastodon [container images](https://hub.docker.com/u/tootsuite) use libvips.
+The official Mastodon [container images](https://hub.docker.com/u/tootsuite) uses libvips.
 ::
 
 ::alert{type="danger"}
-All Mastodon installs using still using ImageMagick should run at least 6.9.7-7 to mitigate CVE-2023-36460, see [this guide](https://github.com/mastodon/mastodon/issues/25776) for more details.
+All Mastodon installs still using ImageMagick should run at least 6.9.7-7 to mitigate CVE-2023-36460, see [this guide](https://github.com/mastodon/mastodon/issues/25776) for more details.
 ::
 
 ### FFmpeg
@@ -192,7 +192,7 @@ There are no specific version requirements for Nginx, and other types of softwar
 ::
 
 ::alert{type="warning"}
-Reguardless of the ingress software that is used, you should keep it up to date to prevent expliotation of known security vulnerabilities.
+Reguardless of the ingress software that is used, you should keep it up to date to prevent exploitation of known security vulnerabilities.
 ::
 
 ## Key
@@ -214,7 +214,8 @@ For the purposes of this document, when applied to dependencies the term "End of
 
 | **Mastodon**  | **Status**         |                                            |
 | ------------- | ------------------ | :----------------------------------------: |
-| 4.4.x         | Development Branch | :icon{name="twemoji:check-box-with-check"} |
+| 4.5.x         | Development Branch | :icon{name="twemoji:check-box-with-check"} |
+| 4.4.x         | Supported Release  |  :icon{name="twemoji:check-mark-button"}   |
 | 4.3.x         | Supported Release  |  :icon{name="twemoji:check-mark-button"}   |
 | 4.2.x         | Supported Release  |  :icon{name="twemoji:check-mark-button"}   |
 | 4.1.x & prior | End of Life        |      :icon{name="twemoji:cross-mark"}      |


### PR DESCRIPTION
Fixed some typos, added 4.4 as supported release, added 4.5 as dev release. 
Still needs to have 4.5 columns added for dependencies.
May also want to add a note about Redis namespaces removed in 4.4 ->